### PR TITLE
Mention support for XPR cut charts in CC API Docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Integrate the Hypertherm Cut Chart API into any application or CNC to give operators access to the latest Hypertherm cut charts. 
 
-Only MAXPRO200 and Powermax105 cut charts are currently supported, but cut charts for more systems will be coming soon.
+Cut charts are available for XPR, MAXPRO200, and Powermax105.
 
 ## Get started
 To use the Hypertherm Cut Chart API in your application:


### PR DESCRIPTION
I updated the ReadMe in the Cutchart-api-docs repo to state that XPR cut charts are also available with the API. The ReadMe does not clarify the distinction that only "base" XPR cut charts are supported right now. If you feel we should mention that detail, please let me know!