### PR TITLE
Discourage use of IE browser 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,6 @@ Find information about the following topics in the [Cut Chart API Support docume
  - authentication
  - API reference information
  - and more! 
+
+## Supported browsers
+The Cut Chart API supports most popular web browsers. However, Microsoft Internet Explorer is not supported. 

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Find information about the following topics in the [Cut Chart API Support docume
  - and more! 
 
 ## Supported browsers
-The Cut Chart API supports most popular web browsers. However, Microsoft Internet Explorer is not supported. 
+The Cut Chart API supports most popular web browsers. However, Microsoft<sup>®</sup> Internet Explorer is not supported. 


### PR DESCRIPTION
Although GitHub doesn't support Internet Explorer, the CC API docs landing page is readable in Internet Explorer (on my laptop at least). As a result, I added a note to the CCAPI docs landing page in GitHub to discourage the use of Internet Explorer.

Does this look OK or do you think we should recommend the use of specific browsers?