### PR TITLE
ReadMe: Update doc links ART-6809

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Integrate the Hypertherm Cut Chart API into any application or CNC to give opera
 Cut charts are available for XPR, MAXPRO200, and Powermax105.
 
 ## Try out the API
-Not sure if you want to integrate the Cut Chart API with your client application? You can [try it out](https://stoplight.io/p/docs/gh/hypertherm/cutchart-api/docs/Support/Try-the-API/About-trial-tools.md?srn=gh/hypertherm/cutchart-api/docs/Support/Try-the-API/About-trial-tools.md) before you decide.
+Not sure if you want to integrate the Cut Chart API with your client application? You can [try it out](https://hypertherm.stoplight.io/docs/cutchart-api/docs/Support/Try-the-API/About-trial-tools.md) before you decide.
 
 ## Integrate the API into my application
 To integrate the Hypertherm Cut Chart API into your client application:
 1. [Register](https://clientregistration.z20.web.core.windows.net/) your application to get a Client ID.
-2. Set up [authentication](https://stoplight.io/p/docs/gh/hypertherm/cutchart-api/docs/Support/authentication.md?srn=gh/hypertherm/cutchart-api/docs/Support/authentication.md).
-3. [Call the API](https://stoplight.io/p/docs/gh/hypertherm/cutchart-api/reference/cutchart-api/openapi.yml?srn=gh/hypertherm/cutchart-api/reference/cutchart-api/openapi.yml) to get and customize Hypertherm cut charts on-demand.
+2. Set up [authentication](https://hypertherm.stoplight.io/docs/cutchart-api/docs/Support/authentication.md).
+3. [Call the API](https://hypertherm.stoplight.io/docs/cutchart-api/reference/cutchart-api/openapi.yml) to get and customize Hypertherm cut charts on-demand.
 
 ## Review example applications
 
@@ -21,7 +21,7 @@ To see the Cut Chart API in action and review sample code, refer to these exampl
   - **Website:** Download [Hypertherm cut charts online](https://cutchartsapp.z20.web.core.windows.net/).
 
 ## Learn more about the API
-Find information about the following topics in the [Cut Chart API Support documentation](https://stoplight.io/p/docs/gh/hypertherm/cutchart-api/docs/Home.md?srn=gh/hypertherm/cutchart-api/docs/Home.md):
+Find information about the following topics in the [Cut Chart API Support documentation](https://hypertherm.stoplight.io/docs/cutchart-api/docs/Home.md):
  - custom cut charts and templates
  - authentication
  - API reference information


### PR DESCRIPTION
Stoplight has confirmed that our current Stoplight documentation URL will only be available through the end of August! Thanks to Richard for realizing that this change could happen! 

This PR updates the ReadMe to replace links to https://stoplight.io/p/docs with links to the new URL: https://hypertherm.stoplight.io/docs/cutchart-api/.

Customers who normally access the docs through this GitHub ReadMe should not be affected, but those who have bookmarked the URL to the Stoplight URL will be affected. We will work with Abhi to communicate with stakeholders.
